### PR TITLE
fix: textureの冗長なところを修正

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -45,8 +45,8 @@ body> :not(.edge) {
   filter: grayscale(100%);
   mix-blend-mode: multiply;
   position: absolute;
-  left: var(--edge-width);
-  top: 0px;
+  left: 0;
+  top: 0;
   width: 100dvw;
   height: 100dvh;
   z-index: -1;

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -41,24 +41,16 @@ body> :not(.edge) {
   width: calc(100dvw - var(--edge-width) * 2);
 }
 
-.texture-box {
-  width: 100%;
-  height: 100%;
-  overflow: hidden;
-  position: absolute;
-  right: 80px;
-}
-
-.texture {
+#texture {
   filter: grayscale(100%);
   mix-blend-mode: multiply;
   position: absolute;
-  left: 0px;
+  left: var(--edge-width);
+  top: 0px;
+  width: 100dvw;
+  height: 100dvh;
   z-index: -1;
-
-  img {
-    width: 1760px;
-  }
+  background-image: url('/static/images/texture1.jpg');
 }
 
 .font-balooda {

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -12,11 +12,7 @@
 
   <body>
     <div class="edge"></div>
-    <div class="texture-box">
-      <div class="texture">
-        <img src="{{ url_for('static', filename='images/texture1.jpg') }}" alt="">
-      </div>
-    </div>
+    <div id="texture"></div>
     <div id="container">
       {% block body %}
       {% endblock %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -7,8 +7,8 @@
     position: relative;
   }
 
-  .texture {
-    opacity: 0%;
+  #texture {
+    display: none;
   }
 
   h1 {


### PR DESCRIPTION
## 現在確認しているバグ
- 例えば `/login` のinputをfocusしようとすると、textureにfocusする。
  - textureがformのところより全面に描画されているせいでtextureにfocusする。
- 先ほどの #12 のバグも今回は `100dvw` を使っているため、そのようなバグは起きない。

## コード改善
- 複数の要素を作ってclassで定義しているのを、単一の要素にしてidの`texture`で定義するように変更。