### PR TITLE
feat:adminページの追加

### DIFF
--- a/app/templates/admin.html
+++ b/app/templates/admin.html
@@ -1,0 +1,90 @@
+{% extends "base.html" %}
+
+{% block head %}
+<style>
+  body {
+    position: relative;
+  }
+  .box{
+    width: 90%;
+    max-width: 1500px;
+    margin: 0 auto;
+    margin-top: 150px;
+  }
+  h1{
+    color :#ffffff;
+    font-size: 64px;
+    margin-bottom: 30px;
+  }
+  .table-wrapper{
+    max-height: 600px;
+    overflow-y: auto;
+    overflow-y: scroll !important;
+    display: block;
+  }
+  table{
+    width: 100%;
+    table-layout: fixed;
+    white-space: nowrap;
+    overflow: hidden;
+    text-align: left;
+    color: rgb(22, 22, 22);
+    background-color: white;
+    border-collapse: separate;     /* ← 重要：border-radiusが効くようにする */
+    border: 4px solid rgb(22,22,22);       /* 外枠の線 */
+    border-radius: 10px;           /* 外枠の角丸 */
+    border-spacing: 0;  
+  }
+  th, td {
+    border: 2px solid rgb(22, 22, 22);        /* セル内の区切り線 */
+    padding: 8px;
+    text-align: left;
+    height: 30px;
+  }
+  th {
+    font-size: 20px;
+    overflow: hidden;
+  }
+  td{
+    font-size: 20px;
+    overflow: hidden;
+    a{
+        text-decoration: none;
+        color: rgb(0, 0, 0);
+    }
+  }
+</style>
+
+{% endblock head %}
+
+{% block body %}
+
+<div class="box">
+    <h1 class="font-zenmaru">管理者用ページ(通報者一覧)</h1>
+    <div class="table-wrapper">
+      <table class="font-zenmaru">
+          <colgroup>
+              <col style="width: 100px;"> <!-- 1列目の幅 -->
+              <col style="width: 150px;">  <!-- 2列目以降（自動調整） -->
+              <col style="width: 200px;">  <!-- 2列目以降（自動調整） -->
+              <col style="width: 150px;">  <!-- 2列目以降（自動調整） -->
+          </colgroup>
+          <tr>
+              <th>日付</th>
+              <th>名前</th>
+              <th>メールアドレス</th>
+              <th>通報者名前</th>
+          </tr>
+          {% for data in datas %}
+          <tr>
+              <td>{{ data[0] }}</td>
+              <td><a href="#">{{ data[1] }}</a></td>
+              <td>{{ data[2] }}</td>
+              <td>{{ data[3] }}</td>
+          </tr>
+          {% endfor %}
+      </table>
+    </div>
+</div>
+
+{% endblock body %}

--- a/app/views/admin.py
+++ b/app/views/admin.py
@@ -5,4 +5,11 @@ blueprint = Blueprint("admin", __name__)
 
 @blueprint.route("/")
 def admin():
-    return render_template("admin.html")
+    test_data = [
+        ["0801", "たけし", "takesi@gmail.com", "ともひさ"],
+        ["0830", "ゆみこ", "superyumiko@gmail.com", "マイケルたけし"],
+    ]
+    if len(test_data) < 10:
+        for _ in range(20 - len(test_data)):
+            test_data.append(["0000", " ", " ", " "])
+    return render_template("admin.html", datas=test_data)


### PR DESCRIPTION
管理者ページを追加しました。
pythonから[日付,名前(被通報者),メールアドレス,名前(通報者)]を渡すと表示されます。
他のページに戻るボタンなど未実装。
名前はaタグになっていないです。
