### PR TITLE
fix:バックグラウンドのテクスチャーに境界線が見えてしまうバグの修正

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -50,7 +50,6 @@ body> :not(.edge) {
   width: 100dvw;
   height: 100dvh;
   z-index: -1;
-  background-image: url('/static/images/texture1.jpg');
 }
 
 .font-balooda {

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -12,7 +12,7 @@
 
   <body>
     <div class="edge"></div>
-    <div id="texture"></div>
+    <img id="texture" src="/static/images/texture1.jpg"></img>
     <div id="container">
       {% block body %}
       {% endblock %}


### PR DESCRIPTION
cssでbackground-imageとして指定していた画像をhtmlのimgタグに変更しました。